### PR TITLE
Feature/avx 67 add debug target

### DIFF
--- a/README
+++ b/README
@@ -224,5 +224,5 @@ We have added the following features/bugfixes:
 
   AVX-61  modified make file to compile to gnu99 standard
 
-  AVX-67  added debug target and phony targets to makefile
-
+  AVX-67  added debug target and phony targets to makefile. Debug target
+          creates logfile, /home/debian/ntripclient/ntripclient.log

--- a/README
+++ b/README
@@ -201,6 +201,18 @@ Matternet Addendum
 ------------------
 We have now forked this open source software in our github.
 
+The standard production version is built with make:
+
+  make
+
+The build a debug version:
+
+  make debug
+
+The debug version creates a logfile with debug output in:
+  /home/debian/ntripclient/ntripclient.log 
+
+
 Expected usage:
 
 ./ntripclient -s <server> -m <mount point> -r <port> -u <Matternet username>

--- a/README
+++ b/README
@@ -222,5 +222,7 @@ We have added the following features/bugfixes:
           connection.  Also removed compiler warnings (that occurred in some
           build environments) and added comments to explain functionality
 
-  AVX-61 modified make file to compile to gnu99 standard
+  AVX-61  modified make file to compile to gnu99 standard
+
+  AVX-67  added debug target and phony targets to makefile
 

--- a/makefile
+++ b/makefile
@@ -9,16 +9,28 @@ LIBS = -lwsock32
 else
 OPTS = -std=gnu99 -Wall -W -O3 
 endif
+DEBUG_OPTS = -DNTRIPCLIENT_DEBUG_LOG
+TARGET_NAME = ntripclient
 
 ntripclient: ntripclient.c serial.c
 	$(CC) $(OPTS) ntripclient.c -o $@ $(LIBS)
 
+debug: ntripclient.c serial.c
+	$(CC) $(OPTS) $(DEBUG_OPTS) ntripclient.c -o $(TARGET_NAME) $(LIBS)
+
+.PHONY : debug
+
 clean:
 	$(RM) ntripclient core*
 
+.PHONY : clean
 
 archive:
 	zip -9 ntripclient.zip ntripclient.c makefile README serial.c
 
+.PHONY : archive
+
 tgzarchive:
 	tar -czf ntripclient.tgz ntripclient.c makefile README serial.c
+
+.PHONY : tgzarchive

--- a/ntripclient.c
+++ b/ntripclient.c
@@ -29,10 +29,6 @@
 
 #include "serial.c"
 
-// uncomment this line to enable a logging to a log file to debug this client.
-// log file is hardcoded to "/home/debian/ntripclient/ntripclient.log"
-//#define NTRIPCLIENT_DEBUG_LOG
-
 #define STDIN_FD (0) // stdin file descriptor
 
 #ifdef WINDOWSVERSION


### PR DESCRIPTION
Added debug target to makefile.

To make a debug version:
`make debug`

No longer need to edit ntripclient.c to create a debug version.

Also added PHONY targets to makefile.